### PR TITLE
Don't swallow ValueError while creating an item

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Don't swallow ValueError while importing a content item.
+  [davisagli]
 
 
 5.0.2 (2022-04-21)

--- a/src/kitconcept/contentcreator/creator.py
+++ b/src/kitconcept/contentcreator/creator.py
@@ -658,6 +658,11 @@ def content_creator_from_folder(
         try:
             with open(filepath, "r") as f:
                 data = json.load(f)
+        except ValueError as e:
+            logger.error('Error in file structure: "{0}": {1}'.format(filepath, e))
+        except FileNotFoundError as e:
+            logger.error('Error in file structure: "{0}": {1}'.format(filepath, e))
+        else:
             data["id"] = splitted_path[-1]
             create_item_runner(
                 container,
@@ -669,10 +674,6 @@ def content_creator_from_folder(
                 base_image_path=base_image_path,
                 do_not_edit_if_modified_after=do_not_edit_if_modified_after,
             )
-        except ValueError as e:
-            logger.error('Error in file structure: "{0}": {1}'.format(filepath, e))
-        except FileNotFoundError as e:
-            logger.error('Error in file structure: "{0}": {1}'.format(filepath, e))
 
     # After creation, we refresh all the content created to update resolveuids
     if len(files) > 0:

--- a/src/kitconcept/contentcreator/creator.py
+++ b/src/kitconcept/contentcreator/creator.py
@@ -254,7 +254,7 @@ def create_item_runner(  # noqa
             try:
                 obj = create(container, type_, id_=id_, title=title)
                 create_object = True
-            except Exception as e:
+            except Exception as e:  # noqa: B902
                 logger.error(
                     "Can not create object {} ({}) in {}, because of {}".format(
                         id_, type_, "/".join(container.getPhysicalPath()), e
@@ -413,16 +413,14 @@ def create_item_runner(  # noqa
             for user, roles in opts.get("local_roles", {}).items():
                 obj.manage_setLocalRoles(user, roles)
 
-        except Exception as e:
+        except Exception as e:  # noqa: B902
             container_path = "/".join(container.getPhysicalPath())
             message = f'Could not edit the fields and properties for object {container_path}/{id_} (type: "{type_}", container: "{container_path}", id: "{id_}", title: "{title}") because: {e}'
             logger.error(message)
             if CONTINUE_ON_ERROR:
                 continue
             if DEBUG:
-                import pdb
-
-                pdb.set_trace()
+                breakpoint()  # noqa: T100
             raise
 
         # Call recursively
@@ -658,10 +656,8 @@ def content_creator_from_folder(
         try:
             with open(filepath, "r") as f:
                 data = json.load(f)
-        except ValueError as e:
-            logger.error('Error in file structure: "{0}": {1}'.format(filepath, e))
-        except FileNotFoundError as e:
-            logger.error('Error in file structure: "{0}": {1}'.format(filepath, e))
+        except (ValueError, FileNotFoundError) as e:
+            logger.error(f'Error in file structure: "{filepath}": {e}')
         else:
             data["id"] = splitted_path[-1]
             create_item_runner(


### PR DESCRIPTION
This exception handling was meant to catch errors while loading JSON, not in create_item_runner