### PR TITLE
Add an option to skip generating image scales

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add the option to disable creating image scales immediately
+  by setting the ``CREATOR_SKIP_SCALES`` environment variable.
+  [davisagli]
 
 
 5.0.3 (2022-06-23)

--- a/README.rst
+++ b/README.rst
@@ -217,7 +217,7 @@ metadata:
             "content-type": "text/plain"}
       }
 
-Alternativelly, you can provide the image an extra property ``set_dummy_image``
+Alternatively, you can provide the image an extra property ``set_dummy_image``
 with an array of (image) field names that will create a dummy image placeholder
 in the specified fields in the to be created content type::
 
@@ -258,7 +258,10 @@ Again, a deprecated form is also supported (it will create the image in the
         "set_local_image": "image.png"
       }
 
-the same syntax is valid for files::
+By default, image scales are generated immediately. To disable this,
+set the ``CREATOR_SKIP_SCALES`` environment variable.
+
+The same syntax is valid for files::
 
       {
         "id": "an-file",
@@ -267,7 +270,7 @@ the same syntax is valid for files::
         "set_dummy_file": ["file"]
       }
 
-the deprecated form is also supported (it will create the file in the
+The deprecated form is also supported (it will create the file in the
 ``file`` field)::
 
       {

--- a/src/kitconcept/contentcreator/creator.py
+++ b/src/kitconcept/contentcreator/creator.py
@@ -232,6 +232,7 @@ def create_item_runner(  # noqa
 
     DEBUG = os.environ.get("CREATOR_DEBUG")
     CONTINUE_ON_ERROR = os.environ.get("CREATOR_CONTINUE_ON_ERROR")
+    SKIP_SCALES = os.environ.get("CREATOR_SKIP_SCALES")
 
     for data in content_structure:
         type_ = data.get("@type", None)
@@ -334,13 +335,14 @@ def create_item_runner(  # noqa
                 if not getattr(deserializer, "notifies_create", False):
                     notify(ObjectCreatedEvent(obj))
                 obj = add(container, obj, rename=not bool(id_))
-                for image_fieldname in image_fieldnames_added:
-                    logger.debug(
-                        "{} - generating image scales for {} field".format(
-                            "/".join(obj.getPhysicalPath()), image_fieldname
+                if not SKIP_SCALES:
+                    for image_fieldname in image_fieldnames_added:
+                        logger.debug(
+                            "{} - generating image scales for {} field".format(
+                                "/".join(obj.getPhysicalPath()), image_fieldname
+                            )
                         )
-                    )
-                    plone_scale_generate_on_save(obj, request, image_fieldname)
+                        plone_scale_generate_on_save(obj, request, image_fieldname)
             else:
                 if deserializer.modified:
                     descriptions = []


### PR DESCRIPTION
Add a way to opt out of generating image scales immediately.

I want to experiment and find out whether doing so is really necessary, since it slows down content creation quite a bit.