### PR TITLE
Add option to order creation by type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,15 @@ Changelog
 5.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ``content_creator_from_folder`` now accepts an optional list ``types_order``
+  to prefer loading particular content types earlier
+  [davisagli]
 
+- Improved logging to include the content type.
+  [davisagli]
+
+- Refactored to use ``pathlib`` internally.
+  [davisagli]
 
 5.0.4 (2022-07-26)
 ------------------
@@ -15,6 +22,10 @@ Changelog
 
 - Add the option to disable creating image scales immediately
   by setting the ``CREATOR_SKIP_SCALES`` environment variable.
+  [davisagli]
+
+- If the ``id`` in JSON doesn't match the id from the filename,
+  prefer the one in the JSON.
   [davisagli]
 
 

--- a/src/kitconcept/contentcreator/creator.py
+++ b/src/kitconcept/contentcreator/creator.py
@@ -600,7 +600,7 @@ def content_creator_from_folder(
             modify_siteroot(root_info)
             continue
         elif path.name == "translations.csv":
-            translation_map = os.path.join(folder, "translations.csv")
+            translation_map = path
             continue
 
         try:
@@ -611,18 +611,17 @@ def content_creator_from_folder(
 
     # Apply ordering rules:
     # - Create containers first (lower depth in content tree first)
-    # - types_order
     # - custom_order
+    # - types_order
     # - alphabetical by id
     def sort_key(item: Item):
+        name = item.path.name
         item_type = item.structure.get("@type", "")
         return (
-            len(item.path.name.split(".")[:-1]),  # depth
+            len(name.split(".")[:-1]),  # depth
+            custom_order.index(name) if name in custom_order else maxsize,
             types_order.index(item_type) if item_type in types_order else maxsize,
-            custom_order.index(item)
-            if item in custom_order
-            else maxsize,  # custom order
-            item.path.name.lower(),  # alphabetical
+            name.lower(),  # alphabetical
         )
     items.sort(key=sort_key)
 
@@ -638,8 +637,8 @@ def content_creator_from_folder(
         if container is None:
             container = create_object(plone_path)
         else:
-            if "id" not in data:
-                data["id"] = splitted_path[-1]
+            if "id" not in item.structure:
+                item.structure["id"] = splitted_path[-1]
             create_item_runner(
                 container,
                 [item.structure],

--- a/src/kitconcept/contentcreator/creator.py
+++ b/src/kitconcept/contentcreator/creator.py
@@ -106,12 +106,13 @@ def create_object(path, is_folder=False):
     else:
         parent = create_object(path_parent, is_folder=True)
 
-    logger.info(f"{path} - create")
-
+    type_ = "Folder" if is_folder else "Document"
     obj = api.content.create(
-        container=parent, type="Folder" if is_folder else "Document", id=obj_id
+        container=parent, type=type_, id=obj_id
     )
     api.content.transition(obj=obj, transition="publish")
+    path = "/".join(obj.getPhysicalPath())
+    logger.info(f"{path} - created {type_}")
     return obj
 
 
@@ -343,9 +344,9 @@ def create_item_runner(  # noqa
             path = "/".join(obj.getPhysicalPath())
 
             if create_object:
-                logger.info(f"{path} - created")
+                logger.info(f"{path} - created {type_}")
             else:
-                logger.info(f"{path} - edited")
+                logger.info(f"{path} - edited {type_}")
 
             # CONSTRAIN TYPES
             locally_allowed_types = opts.get("locally_allowed_types", False)

--- a/src/kitconcept/contentcreator/creator.py
+++ b/src/kitconcept/contentcreator/creator.py
@@ -29,8 +29,11 @@ from zope.lifecycleevent import Attributes
 from zope.lifecycleevent import ObjectCreatedEvent
 from zope.lifecycleevent import ObjectModifiedEvent
 
+from dataclasses import dataclass
+from typing import Optional
 import json
 import os
+import pathlib
 
 
 DEFAULT_BLOCKS = {
@@ -45,7 +48,7 @@ DEFAULT_BLOCKS_LAYOUT = {
 }
 
 
-def load_json(path, base_path=None):
+def load_json(path: pathlib.Path, base_path: Optional[pathlib.Path] = None):
     """Load JSON from a file.
 
     :param path: Absolute or relative path to the JSON file. If relative,
@@ -58,12 +61,8 @@ def load_json(path, base_path=None):
     :rtype: dict
     """
     if base_path:
-        path = os.path.join(os.path.dirname(base_path), path)
-    content_json = ""
-    with open(path, "r") as file_handle:
-        content_json = json.loads(file_handle.read())
-
-    return content_json
+        path = base_path / path
+    return json.loads(path.read_text())
 
 
 def set_exclude_from_nav(obj):
@@ -471,7 +470,7 @@ def refresh_objects_created_by_structure(container, content_structure):
             )
 
 
-def refresh_objects_created_by_file(filepath, file_):
+def refresh_objects_created_by_file(path: pathlib.Path):
     def deserialize(obj, blocks=None, validate_all=False):
         request = getRequest()
         request["BODY"] = json.dumps({"blocks": blocks})
@@ -490,19 +489,25 @@ def refresh_objects_created_by_file(filepath, file_):
         serializer = getMultiAdapter((field, context, request), IFieldSerializer)
         return serializer()
 
-    splitted_path = os.path.splitext(file_)[0].split(".")
-    path = "/" + "/".join(splitted_path[:-1])
+    splitted_path = path.stem.split(".")
+    plone_path = "/" + "/".join(splitted_path[:-1])
     id_ = splitted_path[-1]
     try:
-        container = api.content.get(path=path)
+        container = api.content.get(path=plone_path)
     except NotFound:
-        logger.error('Could not look up container under "{}"'.format(path))
+        logger.error('Could not look up container under "{}"'.format(plone_path))
         return
 
     obj = container.get(id_, None)
     if obj and IBlocks.providedBy(obj):
         blocks_serialized = serialize(obj)
         deserialize(obj, blocks_serialized)
+
+
+@dataclass
+class Item:
+    path: pathlib.Path
+    structure: dict
 
 
 def content_creator_from_folder(
@@ -513,6 +518,7 @@ def content_creator_from_folder(
     ignore_wf_types=["Image", "File"],
     logger=logger,
     temp_enable_content_types=[],
+    types_order=[],
     custom_order=[],
     do_not_edit_if_modified_after=None,
     exclude=[],
@@ -555,34 +561,27 @@ def content_creator_from_folder(
     for content_type in temp_enable_content_types:
         enable_content_type(portal, content_type)
 
-    folder = os.path.join(os.path.dirname(__file__), folder_name)
+    folder = pathlib.Path(__file__).parent / folder_name
 
-    # Get files in the right order
-    def sort_key(item):
-        return (
-            len(item.split(".")[:-1]),  # First folders
-            custom_order.index(item)
-            if item in custom_order
-            else maxsize,  # Custom order
-            item.lower(),  # Than alphabetically
-        )
-
-    files = [
-        filename
-        for filename in sorted(os.listdir(folder), key=sort_key)
-        if not filename.startswith(tuple(exclude))
-    ]
+    # Load files from folder
+    items = []
     has_content_json = False
-    # has_siteroot_json = False
     translation_map = None
 
-    for file_ in files:
+    for path in folder.iterdir():
+        # Skip explicitly excluded filenames
+        if path.name.startswith(tuple(exclude)):
+            continue
+        # Skip directories
+        if path.is_dir():
+            continue
+
         # If a content.json is found, proceed as if it contains a normal json arrayed
         # structure
-        if file_ == "content.json":
+        if path.name == "content.json":
             has_content_json = True
             logger.debug("content.json file found, creating content")
-            content_structure = load_json(os.path.join(folder, "content.json"))
+            content_structure = load_json(path)
             create_item_runner(
                 api.portal.get(),
                 content_structure,
@@ -594,40 +593,55 @@ def content_creator_from_folder(
                 do_not_edit_if_modified_after=do_not_edit_if_modified_after,
             )
             continue
-        elif file_ == "siteroot.json":
+        elif path.name == "siteroot.json":
             logger.debug("Site root info found, applying changes")
-            root_info = load_json(os.path.join(folder, "siteroot.json"))
+            root_info = load_json(path)
             modify_siteroot(root_info)
             continue
-        # blacklist "images" folder
-        elif file_ == "images":
-            continue
-        elif file_ == "translations.csv":
+        elif path.name == "translations.csv":
             translation_map = os.path.join(folder, "translations.csv")
             continue
 
-        # ex.: file_ = 'de.ueber-uns.json'
-        filepath = os.path.join(folder, file_)
-        # ex.: path = '/de'
-        splitted_path = os.path.splitext(file_)[0].split(".")
-        path = "/" + "/".join(splitted_path[:-1])
         try:
-            container = api.content.get(path=path)
-        except NotFound:
-            logger.error('Could not look up container under "{}"'.format(path))
-        if container is None:
-            container = create_object(path)
-        try:
-            with open(filepath, "r") as f:
-                data = json.load(f)
+            structure = load_json(path)
+            items.append(Item(path, structure))
         except (ValueError, FileNotFoundError) as e:
-            logger.error(f'Error in file structure: "{filepath}": {e}')
+            logger.error(f'Error in file structure: "{path}": {e}')
+
+    # Apply ordering rules:
+    # - Create containers first (lower depth in content tree first)
+    # - types_order
+    # - custom_order
+    # - alphabetical by id
+    def sort_key(item: Item):
+        item_type = item.structure.get("@type", "")
+        return (
+            len(item.path.name.split(".")[:-1]),  # depth
+            types_order.index(item_type) if item_type in types_order else maxsize,
+            custom_order.index(item)
+            if item in custom_order
+            else maxsize,  # custom order
+            item.path.name.lower(),  # alphabetical
+        )
+    items.sort(key=sort_key)
+
+    # Process the items
+    for item in items:
+        # e.g. de.folder.json -> /de
+        splitted_path = item.path.stem.split(".")
+        plone_path = "/" + "/".join(splitted_path[:-1])
+        try:
+            container = api.content.get(path=plone_path)
+        except NotFound:
+            logger.error(f'Could not look up container under "{plone_path}"')
+        if container is None:
+            container = create_object(plone_path)
         else:
             if "id" not in data:
                 data["id"] = splitted_path[-1]
             create_item_runner(
                 container,
-                [data],
+                [item.structure],
                 default_lang=default_lang,
                 default_wf_state=default_wf_state,
                 ignore_wf_types=ignore_wf_types,
@@ -637,11 +651,10 @@ def content_creator_from_folder(
             )
 
     # After creation, we refresh all the content created to update resolveuids
-    if len(files) > 0:
+    if len(items) > 0:
         logger.debug("Refreshing content serialization after creation...")
-    for file_ in files:
-        filepath = os.path.join(folder, file_)
-        refresh_objects_created_by_file(filepath, file_)
+        for item in items:
+            refresh_objects_created_by_file(item.path)
     if has_content_json:
         logger.debug(
             "Refreshing structured (content.json) content serialization after creation..."

--- a/src/kitconcept/contentcreator/tests/content/a-folder.a-link.json
+++ b/src/kitconcept/contentcreator/tests/content/a-folder.a-link.json
@@ -1,0 +1,5 @@
+{
+    "@type": "Link",
+    "title": "Test Link",
+    "remoteUrl": "/a-folder/a-document-1"
+}

--- a/src/kitconcept/contentcreator/tests/test_creation.py
+++ b/src/kitconcept/contentcreator/tests/test_creation.py
@@ -179,7 +179,13 @@ class CreatorTestCase(unittest.TestCase):
 
         self.assertEqual(["front-page", "a-folder"], self.portal.contentIds())
         self.assertEqual(
-            ["a-document-1", "a-document-2", "a-document-3", "the-last-document"],
+            [
+                "a-document-1",
+                "a-document-2",
+                "a-document-3",
+                "a-link",
+                "the-last-document",
+            ],
             self.portal["a-folder"].contentIds(),
         )
 
@@ -215,7 +221,7 @@ class CreatorTestCase(unittest.TestCase):
 
         self.assertEqual(["front-page", "a-folder"], self.portal.contentIds())
         self.assertEqual(
-            ["a-document-2", "a-document-3", "the-last-document"],
+            ["a-document-2", "a-document-3", "a-link", "the-last-document"],
             self.portal["a-folder"].contentIds(),
         )
 
@@ -233,7 +239,33 @@ class CreatorTestCase(unittest.TestCase):
 
         self.assertEqual(["front-page", "a-folder"], self.portal.contentIds())
         self.assertEqual(
-            ["a-document-2", "a-document-1", "a-document-3", "the-last-document"],
+            [
+                "a-document-2",
+                "a-document-1",
+                "a-document-3",
+                "a-link",
+                "the-last-document",
+            ],
+            self.portal["a-folder"].contentIds(),
+        )
+
+    def test_content_from_folder_types_order(self):
+        path = os.path.join(os.path.dirname(__file__), "content")
+
+        with api.env.adopt_roles(["Manager"]):
+            content_creator_from_folder(
+                folder_name=path,
+                types_order=["Link", "Document"],
+            )
+
+        self.assertEqual(
+            [
+                "a-link",
+                "a-document-1",
+                "a-document-2",
+                "a-document-3",
+                "the-last-document",
+            ],
             self.portal["a-folder"].contentIds(),
         )
 

--- a/src/kitconcept/contentcreator/translations.py
+++ b/src/kitconcept/contentcreator/translations.py
@@ -3,6 +3,7 @@ from .utils import logger
 from kitconcept import api
 
 import csv
+import pathlib
 
 
 try:
@@ -15,21 +16,21 @@ class TranslationError(Exception):
     pass
 
 
-def link_translations(translation_map: str):
+def link_translations(translation_map: pathlib.Path):
     if get_translation_manager is None:
         logger.warn(
             "Content includes translations but plone.app.multilingual is not installed"
         )
         return
 
-    with open(translation_map, "r", newline="") as f:
+    with translation_map.open("r", newline="") as f:
         reader = enumerate(csv.reader(f), start=1)
         next(reader)  # skip header
         for lineno, (canonical_path, translation_path) in reader:
             try:
                 link_translation(canonical_path, translation_path)
             except TranslationError as e:
-                handle_error(f"translations.csv line {lineno}: {e}")
+                handle_error(f"{translation_map.name} line {lineno}: {e}")
 
 
 def link_translation(canonical_path: str, translation_path: str):


### PR DESCRIPTION
Add a `types_order` option to `content_creator_from_folder` to load content types in a specified order. (Containers still need to be created first, of course, and `custom_order` takes precedence over `types_order`)

This provides a way to help deal with problems when items have categorization fields with references to content items of known types. But, it's not perfect and I suspect we may need to iterate further on this.

A more robust solution would be to make the creator aware of which JSON paths include references to other items. Then we could do a graph dependency sort and create them in the correct order. But there are still some edge cases that are trickier like if there are reference cycles.

Or, we could store references and add them at the end after all content has been created. But if the deferred fields are required then we need to suppress validation errors.

Both of those solutions are complex so let's try this first and see if it is good enough.

Also includes some refactoring to use pathlib, and including the type when logging what happened.
